### PR TITLE
optimization: compile pi and euler's number beforehand

### DIFF
--- a/assembly/utils/Math.ts
+++ b/assembly/utils/Math.ts
@@ -24,7 +24,7 @@ export function _normalDensity(std: f32, mean: f32, x: f32): f32 {
 
 export function _standardDeviation(list:f32[]): f32 {
   const mean = _mean(list)
-  const sqrdDiff: f32[] = []
+  const sqrdDiff = new Array<f32>(list.length);
   for (let i = 0; i < list.length; i++){
       sqrdDiff.push((list[i]-mean)*(list[i]-mean))
   }

--- a/assembly/utils/Math.ts
+++ b/assembly/utils/Math.ts
@@ -1,3 +1,7 @@
+const PI_F32 = f32(Math.PI);
+const E_F32 = f32(Math.E);
+const TWO_PI_SQRT_F32 = f32(Math.sqrt(2 * PI_F32));
+
 export function _getMax(arr: Array<f32>): f32 {
     let max = arr[0];
     for (let i = 1; i < arr.length; i++) {
@@ -15,10 +19,7 @@ export function _getMax(arr: Array<f32>): f32 {
 
 
 export function _normalDensity(std: f32, mean: f32, x: f32): f32 {
-  return f32(
-    (f32(Math.E) ** (((x - mean) / std) ** 2 / -2) / std) *
-      Math.sqrt(2 * f32(Math.PI))
-  );
+  return (E_F32 ** (((x - mean) / std) ** 2 / -2) / std) * TWO_PI_SQRT_F32;
 }
 
 export function _standardDeviation(list:f32[]): f32 {


### PR DESCRIPTION
While reading through this repo, I found that in the `_normalDensity` function, Math.PI and Euler's number were being downcast to a f32 from f64 for each computation. I moved them into their own variables so that they are only computed once.

I also set the `sqrdDiff` array in `_standardDeviation` to allocate at its maximum length instead of growing to that length.